### PR TITLE
Adding versions 7.5.0 and 7.5.1 enterprise

### DIFF
--- a/src/main/java/org/jbpm/bootstrap/model/Project.java
+++ b/src/main/java/org/jbpm/bootstrap/model/Project.java
@@ -26,6 +26,8 @@ public class Project implements Serializable {
         this.mappedVersions.put("Enterprise 7.3.1", "7.18.0.Final-redhat-00004");
         this.mappedVersions.put("Enterprise 7.4", "7.23.0.Final-redhat-00002");
         this.mappedVersions.put("Enterprise 7.4.1", "7.23.0.Final-redhat-00003");  
+        this.mappedVersions.put("Enterprise 7.5.0", "7.26.0.Final-redhat-00005");  
+        this.mappedVersions.put("Enterprise 7.5.1", "7.26.0.Final-redhat-00006");          
     }
 
     public String getName() {


### PR DESCRIPTION
Adding versions 7.5.0 and 7.5.1 that are missing on the start.jbpm web page. Let me know if there is any other file or project that should also be changed.